### PR TITLE
Add support for 24bit wave playback

### DIFF
--- a/c_src/simpleaudio.c
+++ b/c_src/simpleaudio.c
@@ -127,8 +127,8 @@ static PyObject* _play_buffer(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    if (bytes_per_channel < 1 || bytes_per_channel > 2) {
-        PyErr_SetString(PyExc_ValueError, "Bytes-per-sample must be 1 (8-bit) or 2 (16-bit).");
+    if (bytes_per_channel < 1 || bytes_per_channel > 3) {
+        PyErr_SetString(PyExc_ValueError, "Bytes-per-sample must be 1 (8-bit), or 2 (16-bit), or 3 (24-bit).");
         return NULL;
     }
 

--- a/c_src/simpleaudio_alsa.c
+++ b/c_src/simpleaudio_alsa.c
@@ -90,6 +90,8 @@ PyObject* play_os(Py_buffer buffer_obj, int len_samples, int num_channels, int b
         sample_format = SND_PCM_FORMAT_U8;
     } else if (bytes_per_chan == 2) {
         sample_format = SND_PCM_FORMAT_S16_LE;
+    } else if (bytes_per_chan == 3) {
+        sample_format = SND_PCM_FORMAT_S24_BE;
     } else {
         ALSA_EXCEPTION("Unsupported Sample Format.", 0, "", err_msg_buf);
         return NULL;


### PR DESCRIPTION
I have a device that records 24bit waves and simpleaudio doesn't need a lot of changing to handle them.  I had to specify the _BE format or else I got massive static from my sound card.  I'm not sure if this is how all machines are set up.