### PR TITLE
Update tutorial.rst

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -183,7 +183,7 @@ the packed 24-bit audio to be played::
    # get timesteps for each sample, T is note duration in seconds
    sample_rate = 44100
    T = 0.5
-   t = np.linspace(0, T, T * sample_rate, False)
+   t = np.linspace(0, T, int(T * sample_rate), False)
 
    # generate sine wave tone
    tone = np.sin(440 * t * 2 * np.pi)


### PR DESCRIPTION
Fixes this issue
```
Traceback (most recent call last):
  File "simple.py", line 14, in <module>
    t = np.linspace(0, T, T * sample_rate, False)
  File "<__array_function__ internals>", line 5, in linspace
  File "/.../site-packages/numpy/core/function_base.py", line 113, in linspace
    num = operator.index(num)
TypeError: 'float' object cannot be interpreted as an integer
```