### PR TITLE
[docs] Coerce linspace to int

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -95,7 +95,7 @@ Here is a full example that plays a few sinewave notes in succession::
    # get timesteps for each sample, T is note duration in seconds
    sample_rate = 44100
    T = 0.25
-   t = np.linspace(0, T, T * sample_rate, False)
+   t = np.linspace(0, T, int(T * sample_rate), False)
 
    # generate sine wave notes
    A_note = np.sin(A_freq * t * 2 * np.pi)
@@ -136,7 +136,7 @@ in one speaker than the other, 'panning' it to one side or the other. The full e
    # get timesteps for each sample, T is note duration in seconds
    sample_rate = 44100
    T = 0.5
-   t = np.linspace(0, T, T * sample_rate, False)
+   t = np.linspace(0, T, int(T * sample_rate), False)
 
    # generate sine wave notes
    A_note = np.sin(A_freq * t * 2 * np.pi)
@@ -183,7 +183,7 @@ the packed 24-bit audio to be played::
    # get timesteps for each sample, T is note duration in seconds
    sample_rate = 44100
    T = 0.5
-   t = np.linspace(0, T, T * sample_rate, False)
+   t = np.linspace(0, T, int(T * sample_rate), False)
 
    # generate sine wave tone
    tone = np.sin(440 * t * 2 * np.pi)


### PR DESCRIPTION
Resolves:
```python
Traceback (most recent call last):
  File "<snip>\play.py", line 2, in <module>
    import numpy as np
play.py' 
Traceback (most recent call last):
  File "<snip>\play.py", line 13, in <module>
    t = np.linspace(0, T, T * sample_rate, False)
  File "<__array_function__ internals>", line 200, in linspace
  File "<snip>\Python310\lib\site-packages\numpy\core\function_base.py", line 121, in linspace
    num = operator.index(num)
TypeError: 'float' object cannot be interpreted as an integer
```
numpy==1.24.1
simpleaudio==1.0.4
Windows 10 19044.2364